### PR TITLE
Develop

### DIFF
--- a/Apps.Smartling/Apps.Smartling.csproj
+++ b/Apps.Smartling/Apps.Smartling.csproj
@@ -15,7 +15,7 @@
       <PackageReference Include="Blackbird.Applications.SDK.Extensions.FileManagement" Version="1.0.2-alpha2" />
       <PackageReference Include="Blackbird.Applications.Sdk.Glossaries.Utils" Version="1.0.0" />
       <PackageReference Include="Blackbird.Applications.Sdk.Utils" Version="1.0.25" />
-      <PackageReference Include="Blackbird.Filters" Version="1.1.57" />
+      <PackageReference Include="Blackbird.Filters" Version="1.1.69" />
       <PackageReference Include="MimeTypes" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>

--- a/Apps.Smartling/Apps.Smartling.csproj
+++ b/Apps.Smartling/Apps.Smartling.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <Product>Smartling</Product>
         <Description>Cloud-based translation management platform that helps businesses efficiently translate and localize content, optimizing global communication strategies through automation and centralized management</Description>
-        <Version>1.7.7</Version>
+        <Version>1.7.8</Version>
         <AssemblyName>Apps.Smartling</AssemblyName>
     </PropertyGroup>
 
@@ -15,7 +15,7 @@
       <PackageReference Include="Blackbird.Applications.SDK.Extensions.FileManagement" Version="1.0.2-alpha2" />
       <PackageReference Include="Blackbird.Applications.Sdk.Glossaries.Utils" Version="1.0.0" />
       <PackageReference Include="Blackbird.Applications.Sdk.Utils" Version="1.0.25" />
-      <PackageReference Include="Blackbird.Filters" Version="1.1.57" />
+      <PackageReference Include="Blackbird.Filters" Version="1.1.69" />
       <PackageReference Include="MimeTypes" Version="2.4.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>

--- a/Apps.Smartling/Constants/ApplicationConstants.cs
+++ b/Apps.Smartling/Constants/ApplicationConstants.cs
@@ -3,5 +3,5 @@
 public class ApplicationConstants
 {
     public const string SmartlingBridgePath = "/webhooks/smartling";
-    public const string BlackbirdToken = "#{SMARTLING_BLACKBIRD_TOKEN}#";
+    public const string BlackbirdToken = "#{BLACKBIRD_SMARTLING_TOKEN}#";
 }

--- a/Apps.Smartling/Utils/SmartlingFileConversionHelper.cs
+++ b/Apps.Smartling/Utils/SmartlingFileConversionHelper.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 using Blackbird.Applications.Sdk.Common.Exceptions;
 using Blackbird.Filters.Transformations;
 
@@ -17,14 +18,39 @@ public static class SmartlingFileConversionHelper
         try
         {
             var fileContent = Encoding.UTF8.GetString(fileBytes);
+            var keyToFieldId = ExtractKeyToFieldIdMap(fileContent);
             var transformation = Transformation.Parse(fileContent, fileName);
-            var xliff = transformation.Serialize();
+            var xliff = transformation.Serialize(unit =>
+                unit.Key != null && keyToFieldId.TryGetValue(unit.Key, out var fieldId)
+                    ? fieldId
+                    : null);
             return new PreparedUploadFile(Encoding.UTF8.GetBytes(xliff), transformation.XliffFileName, "xliff2");
         }
         catch (Exception ex)
         {
             throw new PluginMisconfigurationException($"Failed to convert '{fileName}' from HTML to XLIFF.", ex);
         }
+    }
+
+    private static Dictionary<string, string> ExtractKeyToFieldIdMap(string htmlContent)
+    {
+        var map = new Dictionary<string, string>();
+        var tagPattern = new Regex(@"<[a-zA-Z][^>]*>");
+        var keyAttrPattern = new Regex(@"data-blackbird-key=""([^""]+)""");
+        var fieldIdAttrPattern = new Regex(@"[a-zA-Z][\w-]*field-id=""([^""]+)""");
+
+        foreach (Match tagMatch in tagPattern.Matches(htmlContent))
+        {
+            var tag = tagMatch.Value;
+            var keyMatch = keyAttrPattern.Match(tag);
+            var fieldIdMatch = fieldIdAttrPattern.Match(tag);
+            if (keyMatch.Success && fieldIdMatch.Success)
+            {
+                map[keyMatch.Groups[1].Value] = fieldIdMatch.Groups[1].Value;
+            }
+        }
+
+        return map;
     }
 
     private static bool IsHtmlFile(string fileName, string fileType)

--- a/Tests.Smartling/Tests.Smartling.csproj
+++ b/Tests.Smartling/Tests.Smartling.csproj
@@ -35,10 +35,12 @@
 	  <None Update="TestFiles\**\*">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
+	  <None Update="appsettings.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="TestFiles\Input\" />
     <Folder Include="TestFiles\Output\" />
   </ItemGroup>
 


### PR DESCRIPTION
When uploading a source file to Smartling using the "Upload as XLIFF" option, string keys now show the field name (such as title, description, or buttonText) instead of a generic number